### PR TITLE
Improve and simplify the crate description

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["parsing", "development-tools::debugging"]
 
 [package]
 authors.workspace = true
-description = "A cross-platform, Mach-O and ELF utility to modify installs paths for dynamic libraries or executables."
+description = "A cross-platform binary patching tool for Mach-O and ELF."
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true


### PR DESCRIPTION
I thought the summary in the title of the README was clearer, more current, and more concise than the description in the crate metadata, so this PR proposes updating the description with similar phrasing.

This tool doesn’t just modify install paths (or “installs paths,” an apparent typo) anymore.