### PR TITLE
Include only strictly necessary files in published crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ name = "arwen"
 readme.workspace = true
 repository.workspace = true
 version = "0.0.2"
+include = ["src/**/*", "LICENSE", "README.md"]
 
 [workspace.dependencies]
 goblin = { version = "0.9.3", features = ["mach64"] }


### PR DESCRIPTION
This fixes #26 (at least for users of the published crate) and reduces the crate size by approximately 98%.